### PR TITLE
[mission2] 2단계 미션 구현 - 최시영 / 4팀

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+
+.env

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,7 @@ function App() {
     <Routes>
       <Route element={<Layout />}>
         <Route path="/" element={<MovieList />} />
-        <Route path="/details" element={<MovieDetail />} />
+        <Route path="/details/:id" element={<MovieDetail />} />
       </Route>
     </Routes>
   );

--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -1,4 +1,5 @@
 import { useNavigate } from "react-router-dom";
+import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
 
 function MovieCard({ title, posterPath, voteAverage }) {
   const navigate = useNavigate();
@@ -7,7 +8,7 @@ function MovieCard({ title, posterPath, voteAverage }) {
     navigate("/details");
   };
 
-  const imageUrl = `https://image.tmdb.org/t/p/w500${posterPath}`;
+  const imageUrl = getImageUrl(posterPath); //이미지 경로 변경
 
   return (
     <div

--- a/src/components/MovieCard.jsx
+++ b/src/components/MovieCard.jsx
@@ -1,11 +1,11 @@
 import { useNavigate } from "react-router-dom";
 import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
 
-function MovieCard({ title, posterPath, voteAverage }) {
+function MovieCard({ id, title, posterPath, voteAverage }) {
   const navigate = useNavigate();
 
   const handleClick = () => {
-    navigate("/details");
+    navigate(`/details/${id}`);
   };
 
   const imageUrl = getImageUrl(posterPath); //이미지 경로 변경

--- a/src/components/MovieSlide.jsx
+++ b/src/components/MovieSlide.jsx
@@ -20,6 +20,7 @@ function MovieSlide({ movies }) {
         <SwiperSlide key={movie.id} className={index === 0 ? "ml-16" : ""}>
           <div className="mb-12">
             <MovieCard
+              id={movie.id}
               title={movie.title}
               posterPath={movie.poster_path}
               voteAverage={movie.vote_average}

--- a/src/constans.js
+++ b/src/constans.js
@@ -1,6 +1,6 @@
-export const IMAGE_BASE_URL = "";
+export const TMDB_API_BASE_URL = "https://api.themoviedb.org/3";
 
-export const TMDB_MOVIE_API_BASE_URL = "https://api.themoviedb.org/3/movie";
+export const TMDB_MOVIE_API_BASE_URL = `${TMDB_API_BASE_URL}/movie`;
 
 export const TMDB_GET_OPTION = {
   method: "GET",
@@ -9,3 +9,11 @@ export const TMDB_GET_OPTION = {
     Authorization: `Bearer ${import.meta.env.VITE_TMDP_READ_ACCESS_TOKEN}`,
   },
 };
+
+// MovieList에서 쓸 수 있는 popular 목록 URL
+export const getPopularMoviesUrl = () =>
+  `${TMDB_MOVIE_API_BASE_URL}/popular?language=ko`;
+
+// MovieDetail에서 쓸 수 있는 상세 정보용 URL 생성 함수
+export const getMovieDetailUrl = (id) =>
+  `${TMDB_MOVIE_API_BASE_URL}/${id}?language=ko`;

--- a/src/constans.js
+++ b/src/constans.js
@@ -1,0 +1,11 @@
+export const IMAGE_BASE_URL = "";
+
+export const TMDB_MOVIE_API_BASE_URL = "https://api.themoviedb.org/3/movie";
+
+export const TMDB_GET_OPTION = {
+  method: "GET",
+  headers: {
+    accept: "application/json",
+    Authorization: `Bearer ${import.meta.env.VITE_TMDP_READ_ACCESS_TOKEN}`,
+  },
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,12 +1,10 @@
-export const TMDB_API_BASE_URL = "https://api.themoviedb.org/3";
-
-export const TMDB_MOVIE_API_BASE_URL = `${TMDB_API_BASE_URL}/movie`;
+export const TMDB_MOVIE_API_BASE_URL = "https://api.themoviedb.org/3/movie";
 
 export const TMDB_GET_OPTION = {
   method: "GET",
   headers: {
     accept: "application/json",
-    Authorization: `Bearer ${import.meta.env.VITE_TMDP_READ_ACCESS_TOKEN}`,
+    Authorization: `Bearer ${import.meta.env.VITE_TMDB_READ_ACCESS_TOKEN}`,
   },
 };
 

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
 import { useParams } from "react-router-dom";
-import { getMovieDetailUrl, TMDB_GET_OPTION } from "../constans.js";
+import { getMovieDetailUrl, TMDB_GET_OPTION } from "../constants.js";
 
 function MovieDetail() {
   const { id } = useParams(); // 경로에서 id 가져오는 부분

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,65 +1,78 @@
-import { useState } from "react";
-import movieDetailData from "../data/movieDetailData.json";
+import { useEffect, useState } from "react";
 import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
 import { useParams } from "react-router-dom";
+import { TMDB_MOVIE_API_BASE_URL, TMDB_GET_OPTION } from "../constans.js";
 
 function MovieDetail() {
   const { id } = useParams(); // 경로에서 id 가져오는 부분
-  const [movie] = useState(movieDetailData);
+  const [movie, setMovie] = useState(null);
 
   const imageUrl = getImageUrl(movie.poster_path); // 이미지 경로 변경
   const genres = movie.genres.map((genre) => genre.name).join(", ");
 
-  return (
-    <div style={{ padding: "20px" }}>
-      <div
-        style={{
-          display: "flex",
-          gap: "20px",
-          maxWidth: "1000px",
-          margin: "0 auto",
-        }}
-      >
-        {/* 왼쪽: 포스터 */}
-        <div>
-          <img
-            src={imageUrl}
-            alt={movie.title}
-            style={{ width: "800px", borderRadius: "8px" }}
-          />
-        </div>
+  useEffect(() => {
+    fetch(`${TMDB_MOVIE_API_BASE_URL})/${id}?language=ko`, TMDB_GET_OPTION)
+      .then((res) => res.json())
+      .then((res) => console.log(res));
+  }, [id]);
 
-        {/* 오른쪽: 정보들 */}
-        <div style={{ flexGrow: 1 }}>
-          {/* 제목 + 평점 */}
+  return (
+    <>
+      {movie ? (
+        <div style={{ padding: "20px" }}>
           <div
             style={{
               display: "flex",
-              justifyContent: "space-between",
-              alignItems: "center",
-              marginBottom: "10px",
+              gap: "20px",
+              maxWidth: "1000px",
+              margin: "0 auto",
             }}
           >
-            <h2 style={{ fontSize: "20px", fontWeight: "bold" }}>
-              {movie.title}
-            </h2>
-            <p>⭐ 평점: {movie.vote_average.toFixed(1)}</p>
-          </div>
+            {/* 왼쪽: 포스터 */}
+            <div>
+              <img
+                src={imageUrl}
+                alt={movie.title}
+                style={{ width: "800px", borderRadius: "8px" }}
+              />
+            </div>
 
-          {/* 장르 */}
-          <div style={{ marginBottom: "10px" }}>
-            <strong>장르:</strong> {genres}
-          </div>
+            {/* 오른쪽: 정보들 */}
+            <div style={{ flexGrow: 1 }}>
+              {/* 제목 + 평점 */}
+              <div
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  marginBottom: "10px",
+                }}
+              >
+                <h2 style={{ fontSize: "20px", fontWeight: "bold" }}>
+                  {movie.title}
+                </h2>
+                <p>⭐ 평점: {movie.vote_average.toFixed(1)}</p>
+              </div>
 
-          {/* 줄거리 */}
-          <div>
-            <strong>줄거리</strong>
-            <p>{movie.overview}</p>
+              {/* 장르 */}
+              <div style={{ marginBottom: "10px" }}>
+                <strong>장르:</strong> {genres}
+              </div>
+
+              {/* 줄거리 */}
+              <div>
+                <strong>줄거리</strong>
+                <p>{movie.overview}</p>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+      ) : (
+        <div>로딩중</div>
+      )}
+    </>
   );
 }
+import { TMDB_MOVIE_API_BASE_URL } from "../constans";
 
 export default MovieDetail;

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -5,15 +5,24 @@ import { TMDB_MOVIE_API_BASE_URL, TMDB_GET_OPTION } from "../constans.js";
 
 function MovieDetail() {
   const { id } = useParams(); // 경로에서 id 가져오는 부분
-  const [movie, setMovie] = useState(null);
+  const [movie, setMovie] = useState(undefined);
 
-  const imageUrl = getImageUrl(movie.poster_path); // 이미지 경로 변경
-  const genres = movie.genres.map((genre) => genre.name).join(", ");
+  const imageUrl = movie ? getImageUrl(movie.poster_path) : ""; // 이미지 경로 변경
+
+  let genres = "";
+
+  if (movie && movie.genres) {
+    const genreNames = movie.genres.map((genre) => genre.name);
+    genres = genreNames.join(", ");
+  }
 
   useEffect(() => {
-    fetch(`${TMDB_MOVIE_API_BASE_URL})/${id}?language=ko`, TMDB_GET_OPTION)
+    fetch(`${TMDB_MOVIE_API_BASE_URL}/${id}?language=ko`, TMDB_GET_OPTION)
       .then((res) => res.json())
-      .then((res) => console.log(res));
+      .then((res) => {
+        console.log(res);
+        setMovie(res);
+      });
   }, [id]);
 
   return (
@@ -73,6 +82,5 @@ function MovieDetail() {
     </>
   );
 }
-import { TMDB_MOVIE_API_BASE_URL } from "../constans";
 
 export default MovieDetail;

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
 import { useParams } from "react-router-dom";
-import { TMDB_MOVIE_API_BASE_URL, TMDB_GET_OPTION } from "../constans.js";
+import { getMovieDetailUrl, TMDB_GET_OPTION } from "../constans.js";
 
 function MovieDetail() {
   const { id } = useParams(); // 경로에서 id 가져오는 부분
@@ -17,7 +17,7 @@ function MovieDetail() {
   }
 
   useEffect(() => {
-    fetch(`${TMDB_MOVIE_API_BASE_URL}/${id}?language=ko`, TMDB_GET_OPTION)
+    fetch(getMovieDetailUrl(id), TMDB_GET_OPTION)
       .then((res) => res.json())
       .then((res) => {
         console.log(res);

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,16 +1,15 @@
 import { useEffect, useState } from "react";
-import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
+import { getImageUrl } from "../utils/getImageUrl";
 import { useParams } from "react-router-dom";
 import { getMovieDetailUrl, TMDB_GET_OPTION } from "../constants.js";
 
 function MovieDetail() {
-  const { id } = useParams(); // 경로에서 id 가져오는 부분
+  const { id } = useParams();
   const [movie, setMovie] = useState(undefined);
 
-  const imageUrl = movie ? getImageUrl(movie.poster_path) : ""; // 이미지 경로 변경
+  const imageUrl = movie ? getImageUrl(movie.poster_path) : "";
 
   let genres = "";
-
   if (movie && movie.genres) {
     const genreNames = movie.genres.map((genre) => genre.name);
     genres = genreNames.join(", ");
@@ -28,56 +27,42 @@ function MovieDetail() {
   return (
     <>
       {movie ? (
-        <div style={{ padding: "20px" }}>
-          <div
-            style={{
-              display: "flex",
-              gap: "20px",
-              maxWidth: "1000px",
-              margin: "0 auto",
-            }}
-          >
+        <section className="p-5">
+          <div className="flex flex-col md:flex-row gap-6 max-w-5xl mx-auto">
             {/* 왼쪽: 포스터 */}
-            <div>
+            <div className="flex-shrink-0">
               <img
                 src={imageUrl}
                 alt={movie.title}
-                style={{ width: "800px", borderRadius: "8px" }}
+                className="w-full md:w-[400px] rounded-lg"
               />
             </div>
 
             {/* 오른쪽: 정보들 */}
-            <div style={{ flexGrow: 1 }}>
+            <div className="flex-grow space-y-4">
               {/* 제목 + 평점 */}
-              <div
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  marginBottom: "10px",
-                }}
-              >
-                <h2 style={{ fontSize: "20px", fontWeight: "bold" }}>
-                  {movie.title}
-                </h2>
-                <p>⭐ 평점: {movie.vote_average.toFixed(1)}</p>
+              <div className="flex justify-between items-center">
+                <h2 className="text-2xl font-bold">{movie.title}</h2>
+                <p className="text-gray-700">
+                  ⭐ 평점: {movie.vote_average.toFixed(1)}
+                </p>
               </div>
 
               {/* 장르 */}
-              <div style={{ marginBottom: "10px" }}>
+              <div>
                 <strong>장르:</strong> {genres}
               </div>
 
               {/* 줄거리 */}
               <div>
                 <strong>줄거리</strong>
-                <p>{movie.overview}</p>
+                <p className="text-gray-800 mt-1">{movie.overview}</p>
               </div>
             </div>
           </div>
-        </div>
+        </section>
       ) : (
-        <div>로딩중</div>
+        <div className="text-center mt-10 text-lg text-gray-500">로딩중...</div>
       )}
     </>
   );

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import movieDetailData from "../data/movieDetailData.json";
 import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
+import { useParams } from "react-router-dom";
 
 function MovieDetail() {
+  const { id } = useParams(); // 경로에서 id 가져오는 부분
   const [movie] = useState(movieDetailData);
 
   const imageUrl = getImageUrl(movie.poster_path); // 이미지 경로 변경

--- a/src/pages/MovieDetail.jsx
+++ b/src/pages/MovieDetail.jsx
@@ -1,10 +1,11 @@
 import { useState } from "react";
 import movieDetailData from "../data/movieDetailData.json";
+import { getImageUrl } from "../utils/getImageUrl"; // 이미지 경로
 
 function MovieDetail() {
   const [movie] = useState(movieDetailData);
 
-  const imageUrl = `https://image.tmdb.org/t/p/w500${movie.poster_path}`;
+  const imageUrl = getImageUrl(movie.poster_path); // 이미지 경로 변경
   const genres = movie.genres.map((genre) => genre.name).join(", ");
 
   return (

--- a/src/pages/MovieList.jsx
+++ b/src/pages/MovieList.jsx
@@ -1,10 +1,21 @@
-import { useState } from "react";
-import movieListData from "../data/movieListData.json";
+import { useEffect, useState } from "react";
+import { getPopularMoviesUrl, TMDB_GET_OPTION } from "../constans.js";
 import MovieCard from "../components/MovieCard";
 import MovieSlide from "../components/MovieSlide";
 
 function MovieList() {
-  const [movies] = useState(movieListData.results);
+  const [movies, setMovies] = useState([]); // TMDb에서 받아온 영화 목록을 저장할 상태
+
+  useEffect(() => {
+    fetch(getPopularMoviesUrl(), TMDB_GET_OPTION)
+      .then((res) => res.json())
+      .then((data) => {
+        // 성인 콘텐츠 제외
+        const filtered = data.results.filter((movie) => movie.adult === false);
+        console.log(filtered);
+        setMovies(filtered);
+      });
+  }, []);
 
   return (
     <div className="min-h-screen bg-gray-100 p-6 space-y-10">

--- a/src/pages/MovieList.jsx
+++ b/src/pages/MovieList.jsx
@@ -21,6 +21,7 @@ function MovieList() {
           {movies.map((movie) => (
             <MovieCard
               key={movie.id}
+              id={movie.id}
               title={movie.title}
               posterPath={movie.poster_path}
               voteAverage={movie.vote_average}

--- a/src/pages/MovieList.jsx
+++ b/src/pages/MovieList.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { getPopularMoviesUrl, TMDB_GET_OPTION } from "../constans.js";
+import { getPopularMoviesUrl, TMDB_GET_OPTION } from "../constants.js";
 import MovieCard from "../components/MovieCard";
 import MovieSlide from "../components/MovieSlide";
 

--- a/src/utils/getImageUrl.js
+++ b/src/utils/getImageUrl.js
@@ -1,0 +1,1 @@
+export const getImageUrl = (path) => `https://image.tmdb.org/t/p/w500${path}`;


### PR DESCRIPTION
## 구현 사항
- 코드리뷰 받은 부분 수정 (이미지 URL 유틸 함수로 분리)
- 성인 영화 필터링
- TMdb DB와 프로젝트와 연결 (API 읽기 액세스 토큰)
- 클릭한 MovieCard에 맞는 MovieDetail로 이동하도록 라우팅

## 어려웠던 점
- 깃 사용이 아직 많이 어려워 생각보다 오래 걸렸습니다.
- API 발급 자체가 처음이라 어려웠습니다.
- 공통적으로 들어가는 코드는 따로 상수 파일을 만드는 것이 쉽지 않았습니다. 
- MovieDetail 이동하는 라우팅 작업 시 디테일 페이지가 오류 발생해 꼬였는데 MovieSlide에 id props 를 주고 해결했습니다.

## 구현 이미지

### 메인페이지 
<img width="1710" alt="스크린샷 2025-06-19 오전 10 35 52" src="https://github.com/user-attachments/assets/641e3ef2-4a79-49df-b8d0-b9244f0edfd4" />


### 디테일 페이지
<img width="1714" alt="스크린샷 2025-06-19 오전 10 36 32" src="https://github.com/user-attachments/assets/7eb4d1ff-18d0-4612-bf78-219a9b9e6b66" />



