### PR TITLE
[Mission 3] 3단계 미션 구현 - 이재은 / 1팀

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,1 +1,14 @@
 @import "tailwindcss";
+
+@font-face {
+  font-family: "YESMyoungjo-Regular";
+  src: url("https://fastly.jsdelivr.net/gh/projectnoonnu/noonfonts_13@1.0/YESMyoungjo-Regular.woff")
+    format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
+* {
+  font-family: "YESMyoungjo-Regular";
+  font-weight: 700;
+}

--- a/src/Components/NavBar.jsx
+++ b/src/Components/NavBar.jsx
@@ -1,18 +1,22 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
 import useDebounce from "../hooks/useDebounce";
-import { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
 
 export default function NavBar() {
   const [movieList, setMovieList] = useState([]);
   const [input, setInput] = useState("");
   const debouncedInput = useDebounce(input, 500);
+  const [, setSearchParams] = useSearchParams();
 
   useEffect(() => {
     if (debouncedInput.trim() === "") {
       setMovieList([]);
+      setSearchParams({});
       return;
     }
+
+    setSearchParams({ query: debouncedInput });
 
     const fetchSearchResults = async () => {
       const token = import.meta.env.VITE_API_TOKEN;

--- a/src/Components/NavBar.jsx
+++ b/src/Components/NavBar.jsx
@@ -41,8 +41,8 @@ export default function NavBar() {
     <div className="flex items-center bg-white h-[40px] px-4">
       {/* 왼쪽: 로고 */}
       <div className="flex-1">
-        <Link to="/" className="text-sm">
-          재은TV
+        <Link to="/" className="text-sm" onClick={() => setInput("")}>
+          잼은TV
         </Link>
       </div>
 

--- a/src/Components/NavBar.jsx
+++ b/src/Components/NavBar.jsx
@@ -1,12 +1,68 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import useDebounce from "../hooks/useDebounce";
+import { useEffect } from "react";
 
 export default function NavBar() {
+  const [movieList, setMovieList] = useState([]);
+  const [input, setInput] = useState("");
+  const debouncedInput = useDebounce(input, 500);
+
+  useEffect(() => {
+    if (debouncedInput) {
+      const fetchSearchResults = async () => {
+        const token = import.meta.env.VITE_API_TOKEN;
+        const apiUrl = import.meta.env.VITE_API_URL;
+
+        const response = await fetch(
+          `${apiUrl}search/movie?query=${debouncedInput}&language=ko-KR&page=1`,
+          {
+            method: "GET",
+            headers: {
+              accept: "application/json",
+              Authorization: `Bearer ${token}`,
+            },
+          }
+        );
+
+        const data = await response.json();
+
+        setMovieList(data);
+      };
+
+      fetchSearchResults();
+    }
+  }, [debouncedInput]);
+
   return (
     <div className="flex bg-emerald-800 h-[30px] flex-wrap">
       <Link to={`/`} className="pr-[50px] pl-[10px] text-[19px]">
         재은TV
       </Link>
-      <input className="w-[60%] mt-[2px] h-[25px] text-white bg-green-50 rounded-[10px] pr-[10px] pl-[10px]"></input>
+      <div>
+        <input
+          className="w-[60%] mt-[2px] h-[25px] text-black bg-green-50 rounded-[10px] pr-[10px] pl-[10px]"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+        {movieList.results && movieList.results.length > 0 && (
+          <ul className="absolute top-[30px] left-0 w-full bg-white text-black rounded-md shadow-md z-10">
+            {movieList.results.map((movie) => (
+              <li key={movie.id} className="p-2 hover:bg-emerald-100">
+                <Link
+                  to={`/detail/${movie.id}`}
+                  className="block w-full h-full"
+                  onClick={() => {
+                    setMovieList([]);
+                  }}
+                >
+                  {movie.title}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
       <div className="pl-[50px] text-[19px]">로그인</div>
       <div className="pl-[10px] text-[19px]">회원가입</div>
     </div>

--- a/src/Components/NavBar.jsx
+++ b/src/Components/NavBar.jsx
@@ -9,29 +9,32 @@ export default function NavBar() {
   const debouncedInput = useDebounce(input, 500);
 
   useEffect(() => {
-    if (debouncedInput) {
-      const fetchSearchResults = async () => {
-        const token = import.meta.env.VITE_API_TOKEN;
-        const apiUrl = import.meta.env.VITE_API_URL;
-
-        const response = await fetch(
-          `${apiUrl}search/movie?query=${debouncedInput}&language=ko-KR&page=1`,
-          {
-            method: "GET",
-            headers: {
-              accept: "application/json",
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
-
-        const data = await response.json();
-
-        setMovieList(data);
-      };
-
-      fetchSearchResults();
+    if (debouncedInput.trim() === "") {
+      setMovieList([]);
+      return;
     }
+
+    const fetchSearchResults = async () => {
+      const token = import.meta.env.VITE_API_TOKEN;
+      const apiUrl = import.meta.env.VITE_API_URL;
+
+      const response = await fetch(
+        `${apiUrl}search/movie?query=${debouncedInput}&language=ko-KR&page=1`,
+        {
+          method: "GET",
+          headers: {
+            accept: "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      const data = await response.json();
+
+      setMovieList(data);
+    };
+
+    fetchSearchResults();
   }, [debouncedInput]);
 
   return (
@@ -46,14 +49,14 @@ export default function NavBar() {
       {/* 가운데: 검색창 */}
       <div className="flex-2 relative">
         <input
-          className="w-full h-[25px] text-white bg-gray-800 rounded-[10px] px-2 text-sm"
+          className="w-full h-[25px] text-white bg-gray-800 rounded-[10px] px-2 text-xs"
           value={input}
           onChange={(e) => setInput(e.target.value)}
         />
         {movieList.results && movieList.results.length > 0 && (
-          <ul className="absolute top-[35px] left-0 w-full bg-white text-black rounded-md shadow-md z-10">
+          <ul className="absolute top-[33px] left-0 w-full bg-gray-800 text-white rounded-b-md shadow-md z-10 text-xs">
             {movieList.results.map((movie) => (
-              <li key={movie.id} className="p-2 hover:bg-emerald-100">
+              <li key={movie.id} className="p-2 hover:bg-gray-700">
                 <Link
                   to={`/detail/${movie.id}`}
                   className="block w-full h-full"

--- a/src/Components/NavBar.jsx
+++ b/src/Components/NavBar.jsx
@@ -35,26 +35,29 @@ export default function NavBar() {
   }, [debouncedInput]);
 
   return (
-    <div className="flex bg-emerald-800 h-[30px] flex-wrap">
-      <Link to={`/`} className="pr-[50px] pl-[10px] text-[19px]">
-        재은TV
-      </Link>
-      <div>
+    <div className="flex items-center bg-white h-[40px] px-4">
+      {/* 왼쪽: 로고 */}
+      <div className="flex-1">
+        <Link to="/" className="text-sm">
+          재은TV
+        </Link>
+      </div>
+
+      {/* 가운데: 검색창 */}
+      <div className="flex-2 relative">
         <input
-          className="w-[60%] mt-[2px] h-[25px] text-black bg-green-50 rounded-[10px] pr-[10px] pl-[10px]"
+          className="w-full h-[25px] text-white bg-gray-800 rounded-[10px] px-2 text-sm"
           value={input}
           onChange={(e) => setInput(e.target.value)}
         />
         {movieList.results && movieList.results.length > 0 && (
-          <ul className="absolute top-[30px] left-0 w-full bg-white text-black rounded-md shadow-md z-10">
+          <ul className="absolute top-[35px] left-0 w-full bg-white text-black rounded-md shadow-md z-10">
             {movieList.results.map((movie) => (
               <li key={movie.id} className="p-2 hover:bg-emerald-100">
                 <Link
                   to={`/detail/${movie.id}`}
                   className="block w-full h-full"
-                  onClick={() => {
-                    setMovieList([]);
-                  }}
+                  onClick={() => setMovieList([])}
                 >
                   {movie.title}
                 </Link>
@@ -63,8 +66,10 @@ export default function NavBar() {
           </ul>
         )}
       </div>
-      <div className="pl-[50px] text-[19px]">로그인</div>
-      <div className="pl-[10px] text-[19px]">회원가입</div>
+      <div className="flex-1 flex justify-end gap-3 text-sm">
+        <div>로그인</div>
+        <div>회원가입</div>
+      </div>
     </div>
   );
 }

--- a/src/hooks/useDebounce.jsx
+++ b/src/hooks/useDebounce.jsx
@@ -1,0 +1,22 @@
+import { useEffect } from "react";
+import { useState } from "react";
+
+const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+    // value가 바뀔때마다 실행, 바뀌면 setTimeout으로 일정 시간후 상태에 값을 넣는다.
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value]);
+  // value가 delay안에 바뀌면 clearTimeout으로 이전 예약 취소한다.
+
+  return debouncedValue; //디바운싱 된 값을 컴포넌트에게 넘겨준다.
+};
+
+export default useDebounce;

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -26,22 +26,26 @@ export default function MovieDetail() {
   }, [id]); // id가 바뀔때마다 리랜더링
 
   return (
-    <div className="flex items-center justify-center gap-8 p-8 bg-emerald-900 min-h-screen text-white">
+    <div className="flex flex-col md:flex-row items-center md:items-start justify-center gap-8 p-4 md:p-8 bg-emerald-900 min-h-screen text-white">
       {detailData && (
         <>
           <img
-            className="w-[200] h-[600px] rounded shadow-lg"
+            className="w-60 md:w-[400px] h-[400px] md:h-[600px] rounded shadow-lg"
             src={`https://image.tmdb.org/t/p/w500${detailData.poster_path}`}
             alt={detailData.title}
           />
 
-          <div className="flex flex-col gap-4">
-            <h2 className="text-3xl font-bold">제목: {detailData.title}</h2>
-            <p className="text-xl">평점: {detailData.vote_average}</p>
-            <p className="text-lg">
+          <div className="flex flex-col gap-3 text-center md:text-left">
+            <h2 className="text-base md:text-lg font-bold">
+              제목: {detailData.title}
+            </h2>
+            <p className="text-sm md:text-base">
+              평점: {detailData.vote_average}
+            </p>
+            <p className="text-sm md:text-base">
               장르: {detailData.genres.map((genre) => genre.name).join(", ")}
             </p>
-            <p className="text-base leading-relaxed max-w-xl">
+            <p className="text-sm md:text-base leading-relaxed max-w-xs md:max-w-xl">
               줄거리: {detailData.overview}
             </p>
           </div>

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -11,7 +11,7 @@ export default function MovieDetail() {
       const apiUrl = import.meta.env.VITE_API_URL;
       // 같은 토큰 가져와 변수 저장
 
-      const res = await fetch(`${apiUrl}${id}?language=ko-KR`, {
+      const res = await fetch(`${apiUrl}movie/${id}?language=ko-KR`, {
         headers: {
           Authorization: `Bearer ${token}`,
           accept: "application/json",

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -26,11 +26,11 @@ export default function MovieDetail() {
   }, [id]); // id가 바뀔때마다 리랜더링
 
   return (
-    <div className="flex flex-col md:flex-row items-center md:items-start justify-center gap-8 p-4 md:p-8 bg-emerald-900 min-h-screen text-white">
+    <div className="flex flex-col md:flex-row items-center md:items-start justify-center gap-8 p-4 md:p-8 bg-gray-900 min-h-screen text-white">
       {detailData && (
         <>
           <img
-            className="w-60 md:w-[400px] h-[400px] md:h-[600px] rounded shadow-lg"
+            className="w-60 md:w-[400px] h-[400px] md:h-[600px] rounded-xl shadow-lg "
             src={`https://image.tmdb.org/t/p/w500${detailData.poster_path}`}
             alt={detailData.title}
           />

--- a/src/pages/MovieCard.jsx
+++ b/src/pages/MovieCard.jsx
@@ -34,13 +34,9 @@ export default function MovieCard() {
 
   return (
     <>
-      <div className="p-2 gap-6 flex flex-wrap items-center justify-center bg-black ">
+      <div className="p-2 gap-6 flex flex-wrap items-center justify-center bg-gray-900 ">
         {movieList.map((results) => (
-          <Link
-            to={`/detail/${results.id}`}
-            key={results.id}
-            className=" border-[1px] border-solid"
-          >
+          <Link to={`/detail/${results.id}`} key={results.id} className=" ">
             <div className="transition-transform duration-300 hover:scale-105">
               <img
                 src={`https://image.tmdb.org/t/p/w500${results.poster_path}`}

--- a/src/pages/MovieCard.jsx
+++ b/src/pages/MovieCard.jsx
@@ -44,7 +44,7 @@ export default function MovieCard() {
             <img
               src={`https://image.tmdb.org/t/p/w500${results.poster_path}`}
               alt={results.title}
-              className="w-[180px] h-[270px] object-cover"
+              className="w-[200px] aspect-[2/3] object-cover"
             />
             <nav className="text-[12px] p-[2px] border-t-[1px] bg-amber-50">
               {results.title}

--- a/src/pages/MovieCard.jsx
+++ b/src/pages/MovieCard.jsx
@@ -1,15 +1,30 @@
 import { useEffect } from "react";
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 export default function MovieCard() {
   const [movieList, setMovieList] = useState([]);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get("query");
 
   useEffect(() => {
     const fetchMovies = async () => {
       const token = import.meta.env.VITE_API_TOKEN;
       const apiUrl = import.meta.env.VITE_API_URL;
-      // .env의 api,url 변수 설정
+
+      let url = "";
+      //url을 빈 문자열로 만들어 놓은 후
+
+      if (query && query.trim() !== "") {
+        url = `${apiUrl}search/movie?query=${encodeURIComponent(
+          query
+        )}&language=ko-KR&page=1`;
+        // encodeURIComponent는 url에 포함될 수 없는 문자들을 안전하게 변환해주는 함수이다.
+        //
+      } else {
+        url = `${apiUrl}movie/popular?language=ko-KR&page=1`;
+        // 쿼리스트링을 받지 못했다면 인기ㅍㅔ이지로 이동
+      }
 
       const response = await fetch(
         `${apiUrl}movie/popular?language=ko-KR&page=1`,
@@ -20,17 +35,17 @@ export default function MovieCard() {
           },
         }
       );
-      const data = await response.json(); //json 형태로 받아온걸 data에 저장
+      const data = await response.json();
 
       const filtered = data.results.filter(
         (results) => results.adult === false
-      ); // data.results.adult가 false한 것만 가져오기
+      );
 
-      setMovieList(filtered); //골라낸것을 상태에 저장
+      setMovieList(filtered);
     };
 
     fetchMovies();
-  }, []);
+  }, [query]);
 
   return (
     <>

--- a/src/pages/MovieCard.jsx
+++ b/src/pages/MovieCard.jsx
@@ -11,12 +11,15 @@ export default function MovieCard() {
       const apiUrl = import.meta.env.VITE_API_URL;
       // .env의 api,url 변수 설정
 
-      const response = await fetch(`${apiUrl}popular?language=ko-KR&page=1`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          accept: "application/json",
-        },
-      });
+      const response = await fetch(
+        `${apiUrl}movie/popular?language=ko-KR&page=1`,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            accept: "application/json",
+          },
+        }
+      );
       const data = await response.json(); //json 형태로 받아온걸 data에 저장
 
       const filtered = data.results.filter(

--- a/src/pages/MovieCard.jsx
+++ b/src/pages/MovieCard.jsx
@@ -34,24 +34,26 @@ export default function MovieCard() {
 
   return (
     <>
-      <div className="p-2 gap-6 flex flex-wrap items-center justify-center bg-emerald-950">
+      <div className="p-2 gap-6 flex flex-wrap items-center justify-center bg-black ">
         {movieList.map((results) => (
           <Link
             to={`/detail/${results.id}`}
             key={results.id}
             className=" border-[1px] border-solid"
           >
-            <img
-              src={`https://image.tmdb.org/t/p/w500${results.poster_path}`}
-              alt={results.title}
-              className="w-[200px] aspect-[2/3] object-cover"
-            />
-            <nav className="text-[12px] p-[2px] border-t-[1px] bg-amber-50">
-              {results.title}
-            </nav>
-            <nav className="text-[10px] p-[2px] bg-amber-50">
-              {results.vote_average}
-            </nav>
+            <div className="transition-transform duration-300 hover:scale-105">
+              <img
+                src={`https://image.tmdb.org/t/p/w500${results.poster_path}`}
+                alt={results.title}
+                className="w-[200px] aspect-[2/3] object-cover rounded-t-xl"
+              />
+              <nav className="text-[12px] p-[2px] border-t-[1px] bg-amber-50">
+                {results.title}
+              </nav>
+              <nav className="text-[10px] p-[2px] rounded-b-xl bg-amber-50">
+                {results.vote_average}
+              </nav>
+            </div>
           </Link>
         ))}
       </div>


### PR DESCRIPTION
<!-- PR 제목 예시:
[missionX] X단계 미션 구현 - 000/0팀
-->

## 구현 사항
- debounce 커스텀 훅 구현 후 TMdb 검색 API를 호출하여 검색 결과를 가져오는 함수를 생성
- 검색 시 영화 제목 목록만 띄워 클릭시 그 영화의 해당 아이디와 일치한 디테일 페이지 이동
- 반응형 디자인
- 검색 시 배열 비우기, 로고 클릭시 인풋 비우기 등 작은 부분 개선

## 어려웠던 점
- 커스텀 훅 생성 후 사용 방법에서 애먹음
- 디자인이 제일 어려움.
- 모바일 뷰로 보면 회원가입이 자꾸 아래로 가서 각각 로고, 인풋, 로그인/화원가입에 flex 값을 입력해 해결

## 구현 이미지
- 
<img width="965" alt="스크린샷 2025-06-20 오후 2 52 52" src="https://github.com/user-attachments/assets/4f57770e-67be-49b7-83fe-99ee6b0f5d3e" />

<img width="960" alt="스크린샷 2025-06-20 오후 2 53 20" src="https://github.com/user-attachments/assets/a43d34c4-9c50-48f0-b3d3-ad4dba72547a" />
<img width="960" alt="스크린샷 2025-06-20 오후 2 53 37" src="https://github.com/user-attachments/assets/ccdd504b-30b0-491f-9093-2722d448992f" />
<img width="636" alt="스크린샷 2025-06-20 오후 2 53 53" src="https://github.com/user-attachments/assets/0fcb766f-e01b-41af-a367-800f302f6573" />

